### PR TITLE
Timeout configuration

### DIFF
--- a/e-Tracker/libraries/ElementzGSM.cpp
+++ b/e-Tracker/libraries/ElementzGSM.cpp
@@ -261,7 +261,7 @@ boolean ElementzGSMshield::sendSms(const char* phone_number, const char* Content
     mySerial->print(Content);
  #if (DEBUG == 1)
     Serial.println(Content);
-#endif  
+#endif
     mySerial->write(0x1A);
     SMSsenderString = readReply(120000, 1);
 #if (DEBUG == 1)
@@ -290,7 +290,7 @@ boolean ElementzGSMshield::sendSms(String phone_number, String Content)
     mySerial->print(Content);
  #if (DEBUG == 1)
     Serial.println(Content);
-#endif   
+#endif
     mySerial->write(0x1A);
     SMSsenderString = readReply(120000, 1);
 #if (DEBUG == 1)
@@ -567,6 +567,7 @@ boolean ElementzGSMshield::initializeHTTPService(void)
   if (http_status == true)
   {
     http_status = SendAT("AT+HTTPPARA=\"CID\",1", "OK", 2000, 1, 1);
+    http_status = SendAT("AT+HTTPPARA=\"TIMEOUT\",30", "OK", 2000, 1, 1);
   }
   return http_status;
 
@@ -586,7 +587,7 @@ boolean ElementzGSMshield::sendHTTPDATA(const char* URL_attached_with_data)
     http_status = SendAT("AT+HTTPPARA=\"URL\",\"" + String(URL_attached_with_data) + "\"", "OK", 10000, 1, 1);
     if (http_status == true)
     {
-      http_status = SendAT("AT+HTTPACTION=0", "200", 10000, 1, 3);
+      http_status = SendAT("AT+HTTPACTION=0", "200", 31000, 1, 3);
     }
   }
 
@@ -602,7 +603,7 @@ boolean ElementzGSMshield::sendHTTPDATA(String URL_attached_with_data)
     http_status = SendAT("AT+HTTPPARA=\"URL\",\"" + URL_attached_with_data + "\"", "OK", 10000, 1, 1);
     if (http_status == true)
     {
-      http_status = SendAT("AT+HTTPACTION=0", "200", 10000, 1, 3);
+      http_status = SendAT("AT+HTTPACTION=0", "200", 31000, 1, 3);
     }
   }
 


### PR DESCRIPTION
AT+HTTPPARA="TIMEOUT" is 30 seconds. Any request taking more than 30
seconds will automatically timeout. default 120 seconds.  cannot set
less than 30 seconds
AT+HTTPACTION : wait for 31 seconds for the reply. it will definitely
have a response since we have set the above timeout.

Without these changes there is unintended behaviors such as OPERATION
NOT ALLOWED / the SIM module throws the same error for any command until
the gprs disconnects / module is reset. there is significant delay for
getting GPS updates. with this I was able to get a GPS location update /
3 seconds